### PR TITLE
don't inline icb_ismod

### DIFF
--- a/icb.c
+++ b/icb.c
@@ -594,7 +594,7 @@ icb_who(struct icb_session *is, struct icb_group *ig)
 /*
  *  icb_ismod: checks whether group is moderated by "is"
  */
-inline int
+int
 icb_ismod(struct icb_group *ig, struct icb_session *is)
 {
 	return (ig->mod == is);

--- a/icb.h
+++ b/icb.h
@@ -130,7 +130,7 @@ void		icb_delgroup(struct icb_group *);
 void		icb_error(struct icb_session *, const char *, ...);
 void		icb_init(void);
 int		icb_input(struct icb_session *);
-inline int	icb_ismod(struct icb_group *, struct icb_session *);
+int		icb_ismod(struct icb_group *, struct icb_session *);
 int		icb_modpermit(struct icb_session *, int);
 int		icb_pass(struct icb_group *, struct icb_session *,
 		    struct icb_session *);


### PR DESCRIPTION
icb_ismod is used from two files, clang doesn't like it (C99 inlines by default):

```
cc -O2 -pipe -W -Wall -Werror -Wstrict-prototypes -Wmissing-prototypes -Wmissing-declarations -Wshadow -Wpointer-arith -Wcast-qual -Wsign-compare   -nostdinc -idirafter /usr/include -c cmd.c
In file included from cmd.c:28:
./icb.h:133:12: error: inline function 'icb_ismod' is not defined [-Werror,-Wundefined-inline]
```

Since it's only a hint to the compiler, simplest option seems to be to remove "inline".